### PR TITLE
Migrate away from py.path.local

### DIFF
--- a/pytest_eucalyptus/plugin.py
+++ b/pytest_eucalyptus/plugin.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 
 import os
+from pathlib import Path
 
 import pytest
 from aloe.testclass import TestCase
@@ -41,7 +42,7 @@ def pytest_collect_file(path, parent):
     """
     if path.ext == ".feature":
         if hasattr(Feature, "from_parent"):
-            return Feature.from_parent(parent, fspath=path)
+            return Feature.from_parent(parent, path=Path(str(path)))
         else:
             return Feature(path, parent=parent)
 


### PR DESCRIPTION
Pytest, when doing test discovery, issued the following error message:

```
The (fspath: py.path.local) argument to Feature is deprecated. Please use the (path: pathlib.Path) argument instead
```

This commit does that.

Pytest documentation on the change: https://docs.pytest.org/en/latest/deprecations.html#fspath-argument-for-node-constructors-replaced-with-pathlib-path